### PR TITLE
Add docket socket env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ services:
       - SECRET_KEY=my_secret_key
       - USERNAME=admin # Set username for login
       - PASSWORD=admin # Set password for login
+      - DOCKER_SOCKET=unix://var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask_login import (
 # Initialize Flask app
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "defaultsecretkey")
+DOCKER_SOCKET = os.environ.get("DOCKER_SOCKET", "unix://var/run/docker.sock")
 
 CORS(app)
 
@@ -36,7 +37,7 @@ def load_user(user_id):
 
 # Initialize Docker client
 try:
-    client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+    client = docker.DockerClient(base_url=DOCKER_SOCKET)
     client.ping()
     print("Successfully connected to Docker daemon!")
 except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - SECRET_KEY=my_secret_key
       - USERNAME=admin
       - PASSWORD=admin
+      - DOCKER_SOCKET=unix://var/run/docker.sock
     ports:
       - "3420:8000"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
Add new environment variable to specify which docker socket to use, this allows using a docker socket proxy like:

```yaml
services:
  dockpeek:
    image: ghcr.io/dockpeek/dockpeek:latest
    container_name: dockpeek
    ports:
      - "3420:8000"
    environment:
      - SECRET_KEY=my_secret_key
      - USERNAME=admin # Set username for login
      - PASSWORD=admin # Set password for login
      - DOCKER_SOCKET=tcp://dockpeek-socket-proxy:2375
    restart: unless-stopped

  dockpeek-socket-proxy:
    image: ghcr.io/linuxserver/socket-proxy
    container_name: dockpeek-socket-proxy
    restart: unless-stopped
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    environment:
      CONTAINERS: 1
      IMAGES: 1