### PR TITLE
feat: add native Docker Swarm support with service/task dashboard

### DIFF
--- a/docker-compose-swarm-socket.yml
+++ b/docker-compose-swarm-socket.yml
@@ -1,0 +1,55 @@
+services:
+  dockpeek:
+    image: ghcr.io/dockpeek/dockpeek:latest
+    environment:
+      SECRET_KEY: your_secure_secret_key
+      USERNAME: admin
+      PASSWORD: secure_password
+      TRAEFIK_LABELS: "true"
+      DOCKER_HOST: tcp://tasks.socket-proxy:2375  # Connect to Swarm manager via socket-proxy
+    networks:
+      - traefik
+      - socket-proxy
+    # Go ahead and map the port if you don't plan on using Traefik to expose the ui
+    # ports:
+    #   - "3420:8000"
+    deploy:
+      replicas: 1
+      # Adjust as needed
+      labels:
+        traefik.enable: "true"
+        traefik.swarm.network: traefik
+        traefik.http.routers.dockpeek.rule: Host(`dockpeek.example.com`)
+        traefik.http.routers.dockpeek.entrypoints: websecure
+        traefik.http.services.dockpeek.loadbalancer.server.port: 8000
+
+  socket-proxy:
+    image: lscr.io/linuxserver/socket-proxy:latest
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      PING: 1
+      VERSION: 1
+      INFO: 1
+      POST: 1
+      SERVICES: 1     # Enable Swarm services API
+      TASKS: 1        # Enable Swarm tasks API
+      NODES: 1        # Enable Swarm nodes API
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - type: tmpfs
+        target: /run
+        tmpfs:
+          size: 100000000
+    networks:
+      - socket-proxy
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+
+networks:
+  socket-proxy:
+  traefik:
+    external: true

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
       <div class="flex space-x-4 items-center text-sm controls-container">
         <div class="status-filter flex items-center space-x-3">
           <label for="filter-running-checkbox"
+            id="filter-running-label"
             class="text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
             Running only
           </label>


### PR DESCRIPTION
Implements #26 — Adds first-class Swarm support, including service/task listing, Swarm-aware UI filtering, and updated deployment/documentation. Preserves all existing multi-host and standalone features.