### PR TITLE
Enable port detection for containers on macvlan/custom networks

### DIFF
--- a/dockpeek/get_data.py
+++ b/dockpeek/get_data.py
@@ -123,7 +123,6 @@ def extract_swarm_service_ports(service_attrs):
 def extract_container_ports(container_attrs):
     published_ports = []
     ports = container_attrs['NetworkSettings']['Ports']
-    
     if ports:
         for container_port, mappings in ports.items():
             if mappings:
@@ -131,8 +130,25 @@ def extract_container_ports(container_attrs):
                 host_port = m['HostPort']
                 host_ip = m.get('HostIp', '0.0.0.0')
                 published_ports.append((container_port, host_port, host_ip))
-    
+            else:
+                port_num = container_port.split('/')[0]
+                published_ports.append((container_port, port_num, None))
+    else:
+        exposed = container_attrs.get('Config', {}).get('ExposedPorts', {})
+        for container_port in exposed:
+            port_num = container_port.split('/')[0]
+            published_ports.append((container_port, port_num, None))
+
     return published_ports
+
+
+def get_container_network_ip(container_attrs):
+    networks = container_attrs.get('NetworkSettings', {}).get('Networks', {})
+    for network_info in networks.values():
+        ip = network_info.get('IPAddress', '')
+        if ip and ip not in ('0.0.0.0', '127.0.0.1'):
+            return ip
+    return None
 
 
 def extract_labels_data(labels, tags_enable):
@@ -255,13 +271,14 @@ def process_container(container, client, server_name, public_hostname, is_docker
         traefik_routes = extract_traefik_routes(labels, traefik_enabled)
 
         published_ports_data = extract_container_ports(container.attrs)
-        published_ports = [(cp, hp, None) for cp, hp, hi in published_ports_data]
-        host_ips = {cp: hi for cp, hp, hi in published_ports_data}
+        container_network_ip = get_container_network_ip(container.attrs)
 
         port_map = []
-        for container_port, host_port, _ in published_ports:
-            host_ip = host_ips.get(container_port, '0.0.0.0')
-            link_hostname = _get_link_hostname(public_hostname, host_ip, is_docker_host, request_hostname)
+        for container_port, host_port, host_ip in published_ports_data:
+            if host_ip is None and container_network_ip:
+                link_hostname = container_network_ip
+            else:
+                link_hostname = _get_link_hostname(public_hostname, host_ip, is_docker_host, request_hostname)
             link = create_port_link(host_port, labels_data['https_ports_list'], link_hostname, container_port)
             port_map.append({
                 'container_port': container_port,


### PR DESCRIPTION
### Problem
Containers attached to `macvlan` or other custom networks were showing no ports in the UI. On these networks, Docker assigns each container its own IP address directly on the network rather than publishing ports to the host. Because of this, `NetworkSettings.Ports` is either completely empty (`{}`) or contains entries with null mappings (`{"7878/tcp": null}`). The existing port detection code skipped any port without a host binding, resulting in a blank ports column for all macvlan containers.

### Changes (`get_data.py`)

  - `extract_container_ports()` extended to handle two additional cases:
    - Port entries with null mappings (port exposed, no host binding) uses the container port number directly and signals that the container's own IP should be used for links
    - Completely empty `NetworkSettings.Ports` falls back to `Config.ExposedPorts`, which contains the ports declared by the image

  - `get_container_network_ip()` new helper that extracts the container's IP address from `NetworkSettings.Networks`, used when there is no host-bound IP to link against

  - `process_container()` when a port has no host binding, links are built using the container's own network IP (e.g. `http://192.168.1.8:7878`) rather than falling through to the request hostname, which would produce incorrect links

  **Behavior unchanged** for standard bridge-networked containers with published ports.