### PR TITLE
Add IP Address column and IP-based search functionality

### DIFF
--- a/dockpeek/get_data.py
+++ b/dockpeek/get_data.py
@@ -123,7 +123,6 @@ def extract_swarm_service_ports(service_attrs):
 def extract_container_ports(container_attrs):
     published_ports = []
     ports = container_attrs['NetworkSettings']['Ports']
-    
     if ports:
         for container_port, mappings in ports.items():
             if mappings:
@@ -131,8 +130,25 @@ def extract_container_ports(container_attrs):
                 host_port = m['HostPort']
                 host_ip = m.get('HostIp', '0.0.0.0')
                 published_ports.append((container_port, host_port, host_ip))
-    
+            else:
+                port_num = container_port.split('/')[0]
+                published_ports.append((container_port, port_num, None))
+    else:
+        exposed = container_attrs.get('Config', {}).get('ExposedPorts', {})
+        for container_port in exposed:
+            port_num = container_port.split('/')[0]
+            published_ports.append((container_port, port_num, None))
+
     return published_ports
+
+
+def get_container_network_ip(container_attrs):
+    networks = container_attrs.get('NetworkSettings', {}).get('Networks', {})
+    for network_info in networks.values():
+        ip = network_info.get('IPAddress', '')
+        if ip and ip not in ('0.0.0.0', '127.0.0.1'):
+            return ip
+    return None
 
 
 def extract_labels_data(labels, tags_enable):
@@ -255,13 +271,14 @@ def process_container(container, client, server_name, public_hostname, is_docker
         traefik_routes = extract_traefik_routes(labels, traefik_enabled)
 
         published_ports_data = extract_container_ports(container.attrs)
-        published_ports = [(cp, hp, None) for cp, hp, hi in published_ports_data]
-        host_ips = {cp: hi for cp, hp, hi in published_ports_data}
+        container_network_ip = get_container_network_ip(container.attrs)
 
         port_map = []
-        for container_port, host_port, _ in published_ports:
-            host_ip = host_ips.get(container_port, '0.0.0.0')
-            link_hostname = _get_link_hostname(public_hostname, host_ip, is_docker_host, request_hostname)
+        for container_port, host_port, host_ip in published_ports_data:
+            if host_ip is None and container_network_ip:
+                link_hostname = container_network_ip
+            else:
+                link_hostname = _get_link_hostname(public_hostname, host_ip, is_docker_host, request_hostname)
             link = create_port_link(host_port, labels_data['https_ports_list'], link_hostname, container_port)
             port_map.append({
                 'container_port': container_port,

--- a/dockpeek/get_data.py
+++ b/dockpeek/get_data.py
@@ -322,6 +322,7 @@ def process_container(container, client, server_name, public_hostname, is_docker
             'source_url': labels_data['source_url'],
             'custom_url': labels_data['custom_url'],
             'ports': port_map,
+            'ip_address': container_network_ip,
             'traefik_routes': traefik_routes,
             'tags': labels_data['tags'],
             'update_available': update_available,

--- a/dockpeek/get_data.py
+++ b/dockpeek/get_data.py
@@ -146,6 +146,9 @@ def get_container_network_ip(container_attrs):
     networks = container_attrs.get('NetworkSettings', {}).get('Networks', {})
     for network_info in networks.values():
         ip = network_info.get('IPAddress', '')
+        if not ip:
+            ipam = network_info.get('IPAMConfig') or {}
+            ip = ipam.get('IPv4Address', '')
         if ip and ip not in ('0.0.0.0', '127.0.0.1'):
             return ip
     return None

--- a/dockpeek/main.py
+++ b/dockpeek/main.py
@@ -49,6 +49,30 @@ def get_registry_templates():
     from flask import current_app, jsonify
     return jsonify(current_app.config.get("CUSTOM_REGISTRY_TEMPLATES", {}))
 
+_DATA_DIR = '/app/data'
+
+@main_bp.route("/ignored-ips", methods=["GET"])
+@conditional_login_required
+def get_ignored_ips():
+    import os
+    file_path = os.path.join(_DATA_DIR, 'ignored_ips.json')
+    if os.path.exists(file_path):
+        with open(file_path) as f:
+            return jsonify(json.load(f))
+    return jsonify([])
+
+@main_bp.route("/ignored-ips", methods=["POST"])
+@conditional_login_required
+def save_ignored_ips():
+    import os
+    ips = request.get_json()
+    if not isinstance(ips, list):
+        return jsonify({"error": "Expected a list of IPs"}), 400
+    os.makedirs(_DATA_DIR, exist_ok=True)
+    with open(os.path.join(_DATA_DIR, 'ignored_ips.json'), 'w') as f:
+        json.dump(ips, f)
+    return jsonify({"ok": True})
+
 @main_bp.route("/data")
 @conditional_login_required
 def data():

--- a/dockpeek/static/css/styles.css
+++ b/dockpeek/static/css/styles.css
@@ -249,19 +249,18 @@ body.dark-mode #search-input:focus {
 }
 
 
-.free-port-result {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
+.free-port-result,
+.free-ip-chip {
   margin-bottom: 8px;
   padding: 8px 16px;
   background: white;
   border: 2px solid #91bbff;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  z-index: 100;
+  width: fit-content;
 }
 
+.dark-mode .free-ip-chip,
 .dark-mode .free-port-result {
   background: #1f2937;
   border-color: #3b82f6;
@@ -316,6 +315,113 @@ body.dark-mode #search-input:focus {
 
 .copy-port-button.copied {
   background: #10b981;
+}
+
+.skip-ip-button {
+  padding: 6px;
+  background: #f97316;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.skip-ip-button:hover {
+  background: #ea580c;
+}
+
+.dark-mode .skip-ip-button {
+  background: #c2410c;
+}
+
+.dark-mode .skip-ip-button:hover {
+  background: #9a3412;
+}
+
+.manage-skipped-button {
+  padding: 6px;
+  background: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.manage-skipped-button:hover {
+  background: #4b5563;
+}
+
+.dark-mode .manage-skipped-button {
+  background: #4b5563;
+}
+
+.dark-mode .manage-skipped-button:hover {
+  background: #374151;
+}
+
+.skipped-ips-panel {
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.dark-mode .skipped-ips-panel {
+  border-bottom-color: #374151;
+}
+
+.skipped-ips-panel-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.skipped-ips-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.skipped-ip-btn {
+  background: #1f2937;
+  color: #f3f4f6;
+  font-family: monospace;
+  font-size: 13px;
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.skipped-ip-btn:hover {
+  background: #dc2626;
+  color: white;
+  border-color: #dc2626;
+  text-decoration: line-through;
+}
+
+.dark-mode .skipped-ip-btn {
+  background: #374151;
+  color: #e5e7eb;
+  border-color: #4b5563;
+}
+
+.dark-mode .skipped-ip-btn:hover {
+  background: #dc2626;
+  border-color: #dc2626;
 }
 
 #refresh-button {

--- a/dockpeek/static/css/tailwindcss.css
+++ b/dockpeek/static/css/tailwindcss.css
@@ -3,10 +3,10 @@
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
+    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
     --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
@@ -64,7 +64,7 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
@@ -91,7 +91,7 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
     font-feature-settings: var(--default-mono-font-feature-settings, normal);
     font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
@@ -188,13 +188,13 @@
   :-moz-ui-invalid {
     box-shadow: none;
   }
-  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
     appearance: button;
   }
   ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
     height: auto;
   }
-  [hidden]:where(:not([hidden="until-found"])) {
+  [hidden]:where(:not([hidden='until-found'])) {
     display: none !important;
   }
 }
@@ -1451,19 +1451,16 @@ body.dark-mode #search-input:focus {
 #search-input::placeholder {
   color: #bbbfc5;
 }
-.free-port-result {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
+.free-port-result, .free-ip-chip {
   margin-bottom: 8px;
   padding: 8px 16px;
   background: white;
   border: 2px solid #91bbff;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  z-index: 100;
+  width: fit-content;
 }
-.dark-mode .free-port-result {
+.dark-mode .free-ip-chip, .dark-mode .free-port-result {
   background: #1f2937;
   border-color: #3b82f6;
 }
@@ -1509,6 +1506,97 @@ body.dark-mode #search-input:focus {
 }
 .copy-port-button.copied {
   background: #10b981;
+}
+.skip-ip-button {
+  padding: 6px;
+  background: #f97316;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.skip-ip-button:hover {
+  background: #ea580c;
+}
+.dark-mode .skip-ip-button {
+  background: #c2410c;
+}
+.dark-mode .skip-ip-button:hover {
+  background: #9a3412;
+}
+.manage-skipped-button {
+  padding: 6px;
+  background: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.manage-skipped-button:hover {
+  background: #4b5563;
+}
+.dark-mode .manage-skipped-button {
+  background: #4b5563;
+}
+.dark-mode .manage-skipped-button:hover {
+  background: #374151;
+}
+.skipped-ips-panel {
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e5e7eb;
+}
+.dark-mode .skipped-ips-panel {
+  border-bottom-color: #374151;
+}
+.skipped-ips-panel-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+.skipped-ips-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+.skipped-ip-btn {
+  background: #1f2937;
+  color: #f3f4f6;
+  font-family: monospace;
+  font-size: 13px;
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.skipped-ip-btn:hover {
+  background: #dc2626;
+  color: white;
+  border-color: #dc2626;
+  text-decoration: line-through;
+}
+.dark-mode .skipped-ip-btn {
+  background: #374151;
+  color: #e5e7eb;
+  border-color: #4b5563;
+}
+.dark-mode .skipped-ip-btn:hover {
+  background: #dc2626;
+  border-color: #dc2626;
 }
 #refresh-button {
   display: flex;

--- a/dockpeek/static/js/app.js
+++ b/dockpeek/static/js/app.js
@@ -12,6 +12,7 @@ import { initEventListeners, initLogsButtons } from './modules/events.js';
 import { updateSwarmIndicator, initSwarmIndicator, isSwarmMode } from './modules/swarm-indicator.js';
 import { updateContainerStats } from './modules/container-stats.js';
 import { loadRegistryTemplates } from './modules/registry-urls.js';
+import { loadIgnoredIps } from './modules/ignored-ips.js';
 
 const tableRenderer = new TableRenderer('container-row-template', 'container-rows');
 let dragDropHandler = null;
@@ -32,6 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
   
   initSwarmIndicator();
   loadRegistryTemplates();
+  loadIgnoredIps();
   fetchContainerData();
   initEventListeners();
   initLogsButtons();

--- a/dockpeek/static/js/modules/cell-renderer.js
+++ b/dockpeek/static/js/modules/cell-renderer.js
@@ -282,6 +282,14 @@ function normalizeUrl(url) {
   return url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//) ? url : `https://${url}`;
 }
 
+export function renderIpAddress(container, cell) {
+  if (container.ip_address) {
+    cell.textContent = container.ip_address;
+  } else {
+    cell.innerHTML = `<span class="status-none" style="padding-left: 5px;">none</span>`;
+  }
+}
+
 export function renderLogs(container, cell) {
   const logsButton = document.createElement('button');
   logsButton.className = 'logs-button text-gray-500 hover:text-blue-600 p-1 rounded transition-colors';

--- a/dockpeek/static/js/modules/constants.js
+++ b/dockpeek/static/js/modules/constants.js
@@ -44,5 +44,6 @@ export const COLUMN_MAPPINGS = {
   status: { selector: '[data-sort-column="status"]', cellClass: 'table-cell-status' },
   ports: { selector: '[data-sort-column="ports"]', cellClass: 'table-cell-ports' },
   traefik: { selector: '.traefik-column', cellClass: 'table-cell-traefik' },
+  ipaddress: { selector: '[data-sort-column="ipaddress"]', cellClass: 'table-cell-ipaddress' },
   logs: { selector: '[data-sort-column="logs"]', cellClass: 'table-cell-logs' }
 };

--- a/dockpeek/static/js/modules/events.js
+++ b/dockpeek/static/js/modules/events.js
@@ -155,7 +155,7 @@ export function initEventListeners() {
         }
       });
 
-      state.columnOrder.splice(0, state.columnOrder.length, 'name', 'stack', 'server', 'ports', 'traefik', 'image', 'tags', 'logs', 'status');
+      state.columnOrder.splice(0, state.columnOrder.length, 'name', 'stack', 'server', 'ipaddress', 'ports', 'traefik', 'image', 'tags', 'logs', 'status');
       ColumnOrder.reorderMenuItems()
       ColumnOrder.save()
       ColumnOrder.updateTableOrder()

--- a/dockpeek/static/js/modules/filters.js
+++ b/dockpeek/static/js/modules/filters.js
@@ -3,6 +3,7 @@ import { updateSwarmIndicator, isSwarmMode } from './swarm-indicator.js';
 import { renderTable } from '../app.js';
 import { handlePruneImages, initPruneInfo } from './prune.js';
 import { updateContainerStats } from './container-stats.js';
+import { addIgnoredIp, removeIgnoredIp } from './ignored-ips.js';
 
 export function getCachedServerStatus() {
   const cache = state.serverStatusCache;
@@ -276,7 +277,15 @@ export function updateDisplay() {
         }
       });
 
-      const next = occupied.size > 0 ? Math.max(...occupied) + 1 : 1;
+      state.ignoredIps.forEach(ip => {
+        if (ip.startsWith(subnet + '.')) {
+          const lastOctet = parseInt(ip.split('.').pop(), 10);
+          if (!isNaN(lastOctet)) occupied.add(lastOctet);
+        }
+      });
+
+      let next = 2;
+      while (occupied.has(next)) next++;
       showFreeIpResult(`${subnet}.${next}`);
     }
   } else {
@@ -594,7 +603,8 @@ export function showFreePortResult(port) {
     resultDiv.id = 'free-port-result';
     resultDiv.className = 'free-port-result';
     const searchInput = document.getElementById('search-input');
-    searchInput.parentElement.appendChild(resultDiv);
+    const searchRow = searchInput.parentElement;
+    searchRow.parentElement.insertBefore(resultDiv, searchRow);
   }
 
   resultDiv.innerHTML = `
@@ -631,12 +641,29 @@ export function showFreeIpResult(ip) {
   if (!resultDiv) {
     resultDiv = document.createElement('div');
     resultDiv.id = 'free-ip-result';
-    resultDiv.className = 'free-port-result';
+    resultDiv.className = 'free-ip-chip';
     const searchInput = document.getElementById('search-input');
-    searchInput.parentElement.appendChild(resultDiv);
+    const searchRow = searchInput.parentElement;
+    searchRow.parentElement.insertBefore(resultDiv, searchRow);
   }
 
+  const subnet = ip.split('.').slice(0, 3).join('.');
+  const ignoredIps = state.ignoredIps.filter(ignored => ignored.startsWith(subnet + '.'));
+  const hasIgnored = ignoredIps.length > 0;
+
+  const panelWasOpen = !!resultDiv.querySelector('.skipped-ips-panel:not(.hidden)');
+
   resultDiv.innerHTML = `
+    ${hasIgnored ? `
+      <div class="skipped-ips-panel hidden">
+        <div class="skipped-ips-panel-label">Skipped IPs — click to remove</div>
+        <div class="skipped-ips-list">
+          ${ignoredIps.map(skipped => `
+            <button class="skipped-ip-btn" data-ip="${skipped}">${skipped}</button>
+          `).join('')}
+        </div>
+      </div>
+    ` : ''}
     <div class="free-port-content">
       <span class="free-port-label">Next free IP:</span>
       <code class="free-port-number">${ip}</code>
@@ -646,15 +673,58 @@ export function showFreeIpResult(ip) {
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
         </svg>
       </button>
+      <button class="skip-ip-button" data-tooltip="Skip this IP">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"></line>
+        </svg>
+      </button>
+      ${hasIgnored ? `
+        <button class="manage-skipped-button" data-tooltip="Show skipped IPs">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="8" y1="6" x2="21" y2="6"></line>
+            <line x1="8" y1="12" x2="21" y2="12"></line>
+            <line x1="8" y1="18" x2="21" y2="18"></line>
+            <line x1="3" y1="6" x2="3.01" y2="6"></line>
+            <line x1="3" y1="12" x2="3.01" y2="12"></line>
+            <line x1="3" y1="18" x2="3.01" y2="18"></line>
+          </svg>
+        </button>
+      ` : ''}
     </div>
   `;
 
   resultDiv.classList.remove('hidden');
+
+  if (panelWasOpen && hasIgnored) {
+    resultDiv.querySelector('.skipped-ips-panel').classList.remove('hidden');
+  }
+
   const copyButton = resultDiv.querySelector('.copy-port-button');
   if (copyButton) {
     copyButton.removeEventListener('click', handleCopyPortClick);
     copyButton.addEventListener('click', handleCopyPortClick);
   }
+
+  const skipButton = resultDiv.querySelector('.skip-ip-button');
+  if (skipButton) {
+    skipButton.addEventListener('click', () => {
+      addIgnoredIp(ip).then(() => updateDisplay());
+    });
+  }
+
+  const manageButton = resultDiv.querySelector('.manage-skipped-button');
+  if (manageButton) {
+    manageButton.addEventListener('click', () => {
+      resultDiv.querySelector('.skipped-ips-panel').classList.toggle('hidden');
+    });
+  }
+
+  resultDiv.querySelectorAll('.skipped-ip-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      removeIgnoredIp(btn.dataset.ip).then(() => updateDisplay());
+    });
+  });
 }
 
 export function hideFreeIpResult() {

--- a/dockpeek/static/js/modules/filters.js
+++ b/dockpeek/static/js/modules/filters.js
@@ -648,7 +648,9 @@ export function showFreeIpResult(ip) {
   }
 
   const subnet = ip.split('.').slice(0, 3).join('.');
-  const ignoredIps = state.ignoredIps.filter(ignored => ignored.startsWith(subnet + '.'));
+  const ignoredIps = state.ignoredIps
+    .filter(ignored => ignored.startsWith(subnet + '.'))
+    .sort((a, b) => parseInt(a.split('.').pop(), 10) - parseInt(b.split('.').pop(), 10));
   const hasIgnored = ignoredIps.length > 0;
 
   const panelWasOpen = !!resultDiv.querySelector('.skipped-ips-panel:not(.hidden)');

--- a/dockpeek/static/js/modules/filters.js
+++ b/dockpeek/static/js/modules/filters.js
@@ -112,6 +112,7 @@ export function parseAdvancedSearch(searchTerm) {
     ports: [],
     stacks: [],
     ids: [],
+    ips: [],
     general: []
   };
 
@@ -137,6 +138,8 @@ export function parseAdvancedSearch(searchTerm) {
         idValue = idValue.slice(1, -1);
       }
       filters.ids.push(idValue.toLowerCase());
+    } else if (term.startsWith('ip:')) {
+      filters.ips.push(term.substring(3).toLowerCase());
     } else {
       if (term.startsWith('"') && term.endsWith('"')) {
         term = term.slice(1, -1);
@@ -279,6 +282,13 @@ export function updateDisplay() {
         if (!hasAllStacks) return false;
       }
 
+      if (filters.ips.length > 0) {
+        const hasAllIps = filters.ips.every(searchIp =>
+          container.ip_address && container.ip_address.toLowerCase().includes(searchIp)
+        );
+        if (!hasAllIps) return false;
+      }
+
       if (filters.general.length > 0) {
         const hasAllGeneral = filters.general.every(searchTerm => {
           return (
@@ -286,6 +296,7 @@ export function updateDisplay() {
             container.image.toLowerCase().includes(searchTerm) ||
             (container.stack && container.stack.toLowerCase().includes(searchTerm)) ||
             (container.container_id && container.container_id.toLowerCase().includes(searchTerm)) ||
+            (container.ip_address && container.ip_address.toLowerCase().includes(searchTerm)) ||
             container.ports.some(p =>
               p.host_port.includes(searchTerm) ||
               p.container_port.includes(searchTerm)

--- a/dockpeek/static/js/modules/filters.js
+++ b/dockpeek/static/js/modules/filters.js
@@ -337,6 +337,10 @@ export function updateDisplay() {
       };
       valA = getTraefikRoutes(a);
       valB = getTraefikRoutes(b);
+    } else if (state.currentSortColumn === "ipaddress") {
+      const getLastOctet = (ip) => ip ? parseInt(ip.split('.').pop(), 10) : (state.currentSortDirection === "asc" ? Infinity : -1);
+      valA = getLastOctet(a.ip_address);
+      valB = getLastOctet(b.ip_address);
     } else if (typeof valA === "string" && typeof valB === "string") {
       valA = valA.toLowerCase();
       valB = valB.toLowerCase();

--- a/dockpeek/static/js/modules/filters.js
+++ b/dockpeek/static/js/modules/filters.js
@@ -208,7 +208,7 @@ export function updateDisplay() {
 
   const searchTerm = searchInput.value.trim();
 
-  const freeMatch = searchTerm.match(/:free\s*(\d+)?/);
+  const freeMatch = searchTerm.match(/:free(?!ip)\s*(\d+)?/);
   if (freeMatch) {
     const occupiedPorts = new Set();
 
@@ -242,8 +242,48 @@ export function updateDisplay() {
     hideFreePortResult();
   }
 
-  // Remove :free from search term before normal filtering
-  const cleanSearchTerm = searchTerm.replace(/:free\s*\d*/g, '').trim();
+  const freeIpMatch = searchTerm.match(/:freeip\s*([\d.]+)?/);
+  if (freeIpMatch) {
+    const containersToCheck = state.currentServerFilter === "all"
+      ? state.allContainersData
+      : state.allContainersData.filter(c => c.server === state.currentServerFilter);
+
+    let subnet = freeIpMatch[1] ? freeIpMatch[1].replace(/\.$/, '') : null;
+
+    if (!subnet) {
+      const subnetCounts = {};
+      containersToCheck.forEach(c => {
+        if (c.ip_address) {
+          const parts = c.ip_address.split('.');
+          if (parts.length === 4) {
+            const prefix = parts.slice(0, 3).join('.');
+            subnetCounts[prefix] = (subnetCounts[prefix] || 0) + 1;
+          }
+        }
+      });
+      const entries = Object.entries(subnetCounts);
+      if (entries.length > 0) {
+        subnet = entries.sort((a, b) => b[1] - a[1])[0][0];
+      }
+    }
+
+    if (subnet) {
+      const occupied = new Set();
+      containersToCheck.forEach(c => {
+        if (c.ip_address && c.ip_address.startsWith(subnet + '.')) {
+          const lastOctet = parseInt(c.ip_address.split('.').pop(), 10);
+          if (!isNaN(lastOctet)) occupied.add(lastOctet);
+        }
+      });
+
+      const next = occupied.size > 0 ? Math.max(...occupied) + 1 : 1;
+      showFreeIpResult(`${subnet}.${next}`);
+    }
+  } else {
+    hideFreeIpResult();
+  }
+
+  const cleanSearchTerm = searchTerm.replace(/:freeip\s*[\d.]*/g, '').replace(/:free(?!ip)\s*\d*/g, '').trim();
 
   if (cleanSearchTerm) {
     const filters = parseAdvancedSearch(cleanSearchTerm);
@@ -580,6 +620,45 @@ export function showFreePortResult(port) {
 
 export function hideFreePortResult() {
   const resultDiv = document.getElementById('free-port-result');
+  if (resultDiv) {
+    resultDiv.classList.add('hidden');
+  }
+}
+
+export function showFreeIpResult(ip) {
+  let resultDiv = document.getElementById('free-ip-result');
+
+  if (!resultDiv) {
+    resultDiv = document.createElement('div');
+    resultDiv.id = 'free-ip-result';
+    resultDiv.className = 'free-port-result';
+    const searchInput = document.getElementById('search-input');
+    searchInput.parentElement.appendChild(resultDiv);
+  }
+
+  resultDiv.innerHTML = `
+    <div class="free-port-content">
+      <span class="free-port-label">Next free IP:</span>
+      <code class="free-port-number">${ip}</code>
+      <button class="copy-port-button" data-tooltip="Copy to clipboard" data-port="${ip}">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+      </button>
+    </div>
+  `;
+
+  resultDiv.classList.remove('hidden');
+  const copyButton = resultDiv.querySelector('.copy-port-button');
+  if (copyButton) {
+    copyButton.removeEventListener('click', handleCopyPortClick);
+    copyButton.addEventListener('click', handleCopyPortClick);
+  }
+}
+
+export function hideFreeIpResult() {
+  const resultDiv = document.getElementById('free-ip-result');
   if (resultDiv) {
     resultDiv.classList.add('hidden');
   }

--- a/dockpeek/static/js/modules/ignored-ips.js
+++ b/dockpeek/static/js/modules/ignored-ips.js
@@ -1,0 +1,41 @@
+import { apiUrl } from './config.js';
+import { state } from './state.js';
+
+export async function loadIgnoredIps() {
+  try {
+    const res = await fetch(apiUrl('/ignored-ips'));
+    if (res.ok) {
+      const ips = await res.json();
+      state.ignoredIps.splice(0, state.ignoredIps.length, ...ips);
+    }
+  } catch (err) {
+    console.error('Failed to load ignored IPs:', err);
+  }
+}
+
+export async function addIgnoredIp(ip) {
+  if (!state.ignoredIps.includes(ip)) {
+    state.ignoredIps.push(ip);
+  }
+  await _persist();
+}
+
+export async function removeIgnoredIp(ip) {
+  const idx = state.ignoredIps.indexOf(ip);
+  if (idx !== -1) {
+    state.ignoredIps.splice(idx, 1);
+  }
+  await _persist();
+}
+
+async function _persist() {
+  try {
+    await fetch(apiUrl('/ignored-ips'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(state.ignoredIps)
+    });
+  } catch (err) {
+    console.error('Failed to save ignored IPs:', err);
+  }
+}

--- a/dockpeek/static/js/modules/state.js
+++ b/dockpeek/static/js/modules/state.js
@@ -15,7 +15,7 @@ export const state = {
   isDataLoaded: false,
   isCheckingForUpdates: false,
   updateCheckController: null,
-  columnOrder: ['name', 'stack', 'server', 'ports', 'traefik', 'image', 'tags', 'logs', 'status'],
+  columnOrder: ['name', 'stack', 'server', 'ipaddress', 'ports', 'traefik', 'image', 'tags', 'logs', 'status'],
   columnVisibility: {
     name: true,
     server: true,
@@ -25,6 +25,7 @@ export const state = {
     status: true,
     ports: true,
     traefik: true,
+    ipaddress: false,
     logs: true
   }
 };

--- a/dockpeek/static/js/modules/state.js
+++ b/dockpeek/static/js/modules/state.js
@@ -12,6 +12,7 @@ export const state = {
   currentSortColumn: "name",
   currentSortDirection: "asc",
   currentServerFilter: "all",
+  ignoredIps: [],
   isDataLoaded: false,
   isCheckingForUpdates: false,
   updateCheckController: null,

--- a/dockpeek/static/js/modules/table-renderer.js
+++ b/dockpeek/static/js/modules/table-renderer.js
@@ -63,6 +63,10 @@ export class TableRenderer {
     statusCell.className = `py-3 px-4 border-b border-gray-200 table-cell-status ${className}`;
     statusCell.appendChild(span);
 
+    const ipAddressCell = clone.querySelector('[data-content="ipaddress"]');
+    ipAddressCell.classList.add('table-cell-ipaddress');
+    CellRenderer.renderIpAddress(container, ipAddressCell);
+
     const logsCell = clone.querySelector('[data-content="logs"]');
     logsCell.classList.add('table-cell-logs');
     CellRenderer.renderLogs(container, logsCell);

--- a/dockpeek/templates/index.html
+++ b/dockpeek/templates/index.html
@@ -74,7 +74,7 @@
 
       <div class="mb-4 relative flex items-center">
         <input type="text" id="search-input"
-          placeholder="Search: name, image, stack, ip, #tag, :port e.g. ip:192, :3420, or :free 8000"
+          placeholder="Search: name, image, stack, ip, #tag, :port e.g. ip:192, :3420, :free 8000, or :freeip 192.168.1"
           class="w-full p-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
         <div class="absolute right-18 flex items-center space-x-3">
           <button id="clear-search-button" class="mr-3 text-gray-400 hover:text-gray-600 focus:outline-none hidden"

--- a/dockpeek/templates/index.html
+++ b/dockpeek/templates/index.html
@@ -74,7 +74,7 @@
 
       <div class="mb-4 relative flex items-center">
         <input type="text" id="search-input"
-          placeholder="Search: name, image, stack, #tag, :port e.g. :3420, or :free 8000"
+          placeholder="Search: name, image, stack, ip, #tag, :port e.g. ip:192, :3420, or :free 8000"
           class="w-full p-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
         <div class="absolute right-18 flex items-center space-x-3">
           <button id="clear-search-button" class="mr-3 text-gray-400 hover:text-gray-600 focus:outline-none hidden"

--- a/dockpeek/templates/index.html
+++ b/dockpeek/templates/index.html
@@ -197,6 +197,17 @@
               </div>
 
 
+              <div class="column-menu-item draggable" data-column="ipaddress">
+                <div class="drag-handle">⋮⋮</div>
+                <label for="toggle-ipaddress">
+                  <span>IP Address</span>
+                  <div class="toggle-switch">
+                    <input type="checkbox" id="toggle-ipaddress">
+                    <span class="slider"></span>
+                  </div>
+                </label>
+              </div>
+
               <div class="column-menu-item draggable" data-column="logs">
                 <div class="drag-handle">⋮⋮</div>
                 <label for="toggle-logs">
@@ -243,6 +254,11 @@
               class="server-column table-cell-server py-3 px-4 text-left text-sm font-semibold text-gray-700 border-b border-gray-200 sortable-header server-column"
               data-sort-column="server">
               Server
+            </th>
+            <th
+              class="table-cell-ipaddress py-3 px-4 text-left text-sm font-semibold text-gray-700 border-b border-gray-200 sortable-header"
+              data-sort-column="ipaddress">
+              IP Address
             </th>
             <th
               class="table-cell-ports py-3 px-4 text-left text-sm font-semibold text-gray-700 border-b border-gray-200 sortable-header"
@@ -385,6 +401,8 @@
       </td>
       <td class="py-3 px-4 border-b border-gray-200 text-gray-400 text-sm server-column" data-content="server">
         <span data-content="server-name"></span>
+      </td>
+      <td class="py-3 px-4 border-b border-gray-200 table-cell-ipaddress text-gray-600 text-sm" data-content="ipaddress">
       </td>
       <td class="py-3 px-4 border-b border-gray-200" data-content="ports">
       </td>


### PR DESCRIPTION
### Changes                                                                                                                                            
  - Added **IP Address** column to the container table, off by default
  - Column sorts numerically by last octet                                                                                                               
  - Added `ip:` prefix search syntax for precise subnet filtering (e.g. `ip:192.168.1`, `ip:172`)                                                        
  - Extended general text search to also match against IP addresses                                                                                      
  - Added `:freeip` search command that finds the next available IP on a subnet
    - `:freeip` with no argument auto-detects the most common subnet across all containers
    - `:freeip 192.168.1` scopes to a specific subnet
    - **Skip button** marks the suggested IP as ignored and advances to the next available one
    - Skipped IPs persist across sessions via a named Docker volume (`dockpeek_data:/app/data/ignored_ips.json`)
    - **Show skipped IPs** button reveals a collapsible panel listing all ignored IPs; click any to remove it

  ### Usage Examples
  **IP search:**
  - `ip:192.168.1` → all containers on the `192.168.1.x` subnet
  - `ip:172` → containers on `172.x.x.x` (e.g. bridge networks)
  - `ip:192.168.1.8` → exact container match
  - `192.168.1.8` → plain text search, matches IP alongside name/image/etc.

  **Free IP finder:**
  - `:freeip` → auto-detects most common subnet, returns next available IP
  - `:freeip 192.168.1` → next available IP on `192.168.1.x`
  - `:freeip 10.0.0` → next available IP on `10.0.0.x`

 > **Note:** Requires addition of a named volume in the compose file to persist ignored IP data:
 ```yaml
volumes:
- dockpeek_data:/app/data

 # top-level:
volumes:
  dockpeek_data:
 ```

<img width="565" height="267" alt="image" src="https://github.com/user-attachments/assets/bf9b32bc-84bc-4a96-8510-047593995bcf" />

<img width="567" height="266" alt="image" src="https://github.com/user-attachments/assets/8105d1ce-8813-4b70-9325-b1a38a1ec949" />

<img width="566" height="338" alt="image" src="https://github.com/user-attachments/assets/b545fa3f-6bf3-4085-9b14-e98420d7c192" />

Relates to #85, #54 