### PR TITLE
Support docker secrets via *_FILE env vars alternatives

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import os, json
 from datetime import timedelta
+from pathlib import Path
 
 
 def load_custom_registry_templates():
@@ -8,19 +9,36 @@ def load_custom_registry_templates():
         return json.loads(raw)
     except Exception:
         return {}
-        
+
+def resolve_env(var_name: str, default: str | None = None) -> str | None:
+    file_var = f"{var_name}_FILE"
+
+    value = os.environ.get(var_name)
+    file_name = os.environ.get(file_var)
+
+    if value is not None and file_name is not None:
+        raise ValueError(f"{var_name} and {file_var} cannot both be set")
+
+    if value is not None:
+        return value
+
+    if file_name is not None:
+        return Path(file_name).read_text().rstrip("\n")
+
+    return default
+
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY")
+    SECRET_KEY = resolve_env("SECRET_KEY")
     if not SECRET_KEY:
-        raise RuntimeError("ERROR: SECRET_KEY environment variable is not set.")
+        raise RuntimeError("ERROR: Neither SECRET_KEY or SECRET_KEY_FILE environment variables are set.")
 
     DISABLE_AUTH = os.environ.get("DISABLE_AUTH", "false").lower() == "true"
 
     if not DISABLE_AUTH:
-        ADMIN_USERNAME = os.environ.get("USERNAME")
-        ADMIN_PASSWORD = os.environ.get("PASSWORD")
+        ADMIN_USERNAME = resolve_env("USERNAME")
+        ADMIN_PASSWORD = resolve_env("PASSWORD")
         if not ADMIN_USERNAME or not ADMIN_PASSWORD:
-            raise RuntimeError("USERNAME and PASSWORD environment variables must be set.")
+            raise RuntimeError("USERNAME and PASSWORD environment variables (or *_FILE equivalents) must be set.")
     else:
         ADMIN_USERNAME = None
         ADMIN_PASSWORD = None


### PR DESCRIPTION
About docker secrets: https://docs.docker.com/compose/how-tos/use-secrets/


This change mimics docker standard images for postgres and such (see [postgres' docker-entrypoint.sh](https://github.com/docker-library/postgres/blob/d93ff2b0e6bf59ede3ac461542671d1a472882c7/docker-entrypoint.sh#L9-L25) as an example).

I built locally and deployed without further changes, verified default credentials work.

Modified USERNAME, PASSWORD, SECRET_KEY vars, and the credentials changed as expected.

Removed those, added _FILE equivalents, it also worked:

```diff
diff --git a/deploy/docker-compose.yml b/deploy/docker-compose.yml
index 9a0bca9..c4312b2 100644
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -4,16 +4,29 @@ services:
     build:
       context: ../
     environment:
-      - SECRET_KEY=my_secret_key  
-      - USERNAME=admin            
-      - PASSWORD=admin  
+      - SECRET_KEY_FILE=/run/secrets/secret_key
+      - USERNAME_FILE=/run/secrets/username
+      - PASSWORD_FILE=/run/secrets/password
       #- DISABLE_AUTH=true
       - DOCKER_HOST_NAME=Develop
       - LOG_LEVEL=INFO
+    secrets:
+      - username
+      - password
+      - secret_key
     ports:
       - "3420:8000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - "dockpeek.tags=test,build"
-    restart: unless-stopped
\ No newline at end of file
+    restart: unless-stopped
+
+secrets:
+  username:
+    file: ./username
+  password:
+    file: ./password
+  secret_key:
+    file: ./secret_key
+
diff --git a/deploy/password b/deploy/password
new file mode 100644
index 0000000..f3097ab
--- /dev/null
+++ b/deploy/password
@@ -0,0 +1 @@
+password
diff --git a/deploy/secret_key b/deploy/secret_key
new file mode 100644
index 0000000..5c1b149
--- /dev/null
+++ b/deploy/secret_key
@@ -0,0 +1 @@
+hola
diff --git a/deploy/username b/deploy/username
new file mode 100644
index 0000000..27d7766
--- /dev/null
+++ b/deploy/username
@@ -0,0 +1 @@
+username

```