### PR TITLE
Image version checking for when using non-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ services:
 | `dockpeek.link`  | Custom container link | `dockpeek.link=https://app.com` |
 | `dockpeek.port-range-grouping` | Control port range grouping | `dockpeek.port-range-grouping=false` |
 | `dockpeek.tags`  | tags                  | `dockpeek.tags=web,prod`        |
-| `dockpeek.update-tag` | Override tag for update check | `dockpeek.update-tag=latest` |
+| `dockpeek.update-tag` | Override tag for update check (defaults to latest) | `dockpeek.update-tag` |
 
 <br>
 
@@ -527,7 +527,8 @@ networks:
 > You can override this globally set mode by adding the `dockpeek.update-tag` label to a specific container:
 > ```yaml
 > labels:
->   - "dockpeek.update-tag=latest" # Ignore pinned tag and check against latest
+>   - "dockpeek.update-tag" # Ignore pinned tag and check against latest
+>   - "dockpeek.update-tag=1.5" # Or check against a specific version
 > ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ services:
 | `dockpeek.link`  | Custom container link | `dockpeek.link=https://app.com` |
 | `dockpeek.port-range-grouping` | Control port range grouping | `dockpeek.port-range-grouping=false` |
 | `dockpeek.tags`  | tags                  | `dockpeek.tags=web,prod`        |
+| `dockpeek.update-tag` | Override tag for update check | `dockpeek.update-tag=latest` |
 
 <br>
 
@@ -520,6 +521,13 @@ networks:
 > ```yaml
 > environment:
 >   - UPDATE_FLOATING_TAGS=major  # Checks 8-alpine instead of exact 8.2.2-alpine
+> ```
+>
+> **Override per container:**
+> You can override this globally set mode by adding the `dockpeek.update-tag` label to a specific container:
+> ```yaml
+> labels:
+>   - "dockpeek.update-tag=latest" # Ignore pinned tag and check against latest
 > ```
 
 </details>

--- a/dockpeek/get_data.py
+++ b/dockpeek/get_data.py
@@ -166,7 +166,7 @@ def get_or_check_update(cache_key, client, container_or_service, server_name, im
         return cached_update
     
     if is_swarm:
-        return False
+        return {"available": False, "version": None}
     else:
         return update_checker.check_local_image_updates(client, container_or_service, server_name)
 
@@ -221,7 +221,8 @@ def process_swarm_service(service, tasks_by_service, client, server_name, public
             'ports': port_map,
             'traefik_routes': traefik_routes,
             'tags': labels_data['tags'],
-            'update_available': update_available,
+            'update_available': update_available.get('available', False) if isinstance(update_available, dict) else update_available,
+            'update_version': update_available.get('version', None) if isinstance(update_available, dict) else None,
             'port_range_grouping': port_range_grouping
         }
 
@@ -307,7 +308,8 @@ def process_container(container, client, server_name, public_hostname, is_docker
             'ports': port_map,
             'traefik_routes': traefik_routes,
             'tags': labels_data['tags'],
-            'update_available': update_available,
+            'update_available': update_available.get('available', False) if isinstance(update_available, dict) else update_available,
+            'update_version': update_available.get('version', None) if isinstance(update_available, dict) else None,
             'port_range_grouping': port_range_grouping
         }
 

--- a/dockpeek/main.py
+++ b/dockpeek/main.py
@@ -93,12 +93,12 @@ def check_updates():
                 processed_containers += 1
                 key = f"{server['name']}:{container.name}"
                 try:
-                    update_available = update_checker.check_image_updates(
+                    update_result = update_checker.check_image_updates(
                         server['client'], container, server['name']
                     )
-                    updates[key] = update_available
+                    updates[key] = update_result
                 except Exception as e:
-                    updates[key] = False
+                    updates[key] = {"available": False, "version": None}
                     current_app.logger.error(f"Error during update check for {key}: {e}")
                 
                 if update_checker.is_cancelled:
@@ -168,14 +168,14 @@ def check_single_update():
         if update_checker.is_cancelled:
             return jsonify({"cancelled": True}), 200
             
-        update_available = update_checker.check_image_updates(
+        update_result = update_checker.check_image_updates(
             server['client'], container, server_name
         )
         
         key = f"{server_name}:{container_name}" 
         return jsonify({
             "key": key,
-            "update_available": update_available,
+            "update_available": update_result,
             "server_name": server_name,
             "container_name": container_name,
             "cancelled": update_checker.is_cancelled

--- a/dockpeek/static/css/tailwindcss.css
+++ b/dockpeek/static/css/tailwindcss.css
@@ -569,6 +569,9 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .whitespace-nowrap {
+    white-space: nowrap;
+  }
   .whitespace-pre-line {
     white-space: pre-line;
   }
@@ -598,6 +601,9 @@
   }
   .text-green-500 {
     color: var(--color-green-500);
+  }
+  .text-green-600 {
+    color: var(--color-green-600);
   }
   .text-orange-500 {
     color: var(--color-orange-500);

--- a/dockpeek/static/js/modules/data-fetch.js
+++ b/dockpeek/static/js/modules/data-fetch.js
@@ -214,7 +214,7 @@ async function checkUpdatesIndividually() {
       updateProgressModal(processed, total, container.key);
 
       console.log(`Checking ${container.key} (${processed + 1}/${total})`);
-      let updateResult = false;
+      let updateResult = { available: false, version: null };
       let cancelled = false;
 
       try {
@@ -235,7 +235,7 @@ async function checkUpdatesIndividually() {
             cancelled = true;
           } else {
             updateResult = result.update_available;
-            console.log(`${container.key}: ${updateResult ? 'UPDATE AVAILABLE' : 'up to date'}`);
+            console.log(`${container.key}: ${updateResult.available ? 'UPDATE AVAILABLE' : 'up to date'}`);
           }
         }
       } catch (error) {
@@ -275,8 +275,9 @@ async function checkUpdatesIndividually() {
     state.allContainersData.forEach(container => {
       const key = `${container.server}:${container.name}`;
       if (updates.hasOwnProperty(key)) {
-        container.update_available = updates[key];
-        if (updates[key]) {
+        container.update_available = updates[key].available;
+        container.update_version = updates[key].version;
+        if (updates[key].available) {
           updatedContainers.push(container);
         }
       }
@@ -391,6 +392,7 @@ export async function installUpdate(serverName, containerName) {
     state.allContainersData.forEach(container => {
       if (container.server === serverName && container.name === containerName) {
         container.update_available = false;
+        container.update_version = null;
       }
     });
     updateDisplay();

--- a/dockpeek/static/js/modules/modals.js
+++ b/dockpeek/static/js/modules/modals.js
@@ -9,7 +9,11 @@ export function showUpdatesModal(updatedContainers) {
 
   updatedContainers.forEach(container => {
     const li = document.createElement("li");
-    li.innerHTML = `<strong class="container-name">${container.name}</strong> <span class="stack-name">[${container.stack}]</span> <span class="server-name">(${container.server})</span> <span class="image-name">${container.image}</span>`;
+    let versionStr = "";
+    if (container.update_version) {
+      versionStr = ` <span class="text-green-600 font-medium whitespace-nowrap">→ ${container.update_version}</span>`;
+    }
+    li.innerHTML = `<strong class="container-name">${container.name}</strong> <span class="stack-name">[${container.stack}]</span> <span class="server-name">(${container.server})</span> <span class="image-name">${container.image}</span>${versionStr}`;
     updatesList.appendChild(li);
   });
 

--- a/dockpeek/update.py
+++ b/dockpeek/update.py
@@ -144,16 +144,16 @@ class UpdateChecker:
 
     def check_local_image_updates(self, client, container, server_name):
         if self._cancellation.is_cancelled():
-            return False
+            return {"available": False, "version": None}
             
         try:
             container_image_id = container.attrs.get('Image', '')
             if not container_image_id: 
-                return False
+                return {"available": False, "version": None}
                 
             image_name = container.attrs.get('Config', {}).get('Image', '')
             if not image_name: 
-                return False
+                return {"available": False, "version": None}
 
             labels = container.attrs.get('Config', {}).get('Labels', {}) or {}
                 
@@ -162,26 +162,27 @@ class UpdateChecker:
                 
             try:
                 local_image = client.images.get(f"{base_name}:{resolved_tag}")
-                return container_image_id != local_image.id
+                available = container_image_id != local_image.id
+                return {"available": available, "version": resolved_tag if available else None}
             except Exception: 
-                return False
+                return {"available": False, "version": None}
         except Exception as e:
             logger.error(f"Error checking local image updates for container '{container.name}': {e}")
-            return False
+            return {"available": False, "version": None}
     
     def check_image_updates(self, client, container, server_name):
         if self._cancellation.is_cancelled():
             logger.debug(f"Update check cancelled before starting for {container.name}")
-            return False
+            return {"available": False, "version": None}
             
         try:
             container_image_id = container.attrs.get('Image', '')
             if not container_image_id: 
-                return False
+                return {"available": False, "version": None}
                 
             image_name = container.attrs.get('Config', {}).get('Image', '')
             if not image_name: 
-                return False
+                return {"available": False, "version": None}
                 
             cache_key = self.get_cache_key(server_name, container.name, image_name)
             cached_result, is_valid = self.get_cached_result(cache_key)
@@ -199,16 +200,17 @@ class UpdateChecker:
             
             if self._cancellation.is_cancelled():
                 logger.info(f"Update check cancelled before pulling {base_name}:{current_tag} on {server_name}")
-                return False
+                return {"available": False, "version": None}
             
-            result = self._pull_and_compare(client, container_image_id, base_name, resolved_tag, server_name)
+            is_update_available = self._pull_and_compare(client, container_image_id, base_name, resolved_tag, server_name)
+            result = {"available": is_update_available, "version": resolved_tag if is_update_available else None}
             self.set_cache_result(cache_key, result)
             return result
                 
         except Exception as e:
             if not self._cancellation.is_cancelled():
                 logger.error(f"Error checking image updates for '{container.name}' on {server_name}: {e}")
-            return False
+            return {"available": False, "version": None}
 
     def _parse_image_name(self, image_name):
         if ':' in image_name: 

--- a/dockpeek/update.py
+++ b/dockpeek/update.py
@@ -163,7 +163,8 @@ class UpdateChecker:
             try:
                 local_image = client.images.get(f"{base_name}:{resolved_tag}")
                 available = container_image_id != local_image.id
-                return {"available": available, "version": resolved_tag if available else None}
+                update_version = self._extract_image_version(local_image, resolved_tag) if available else None
+                return {"available": available, "version": update_version}
             except Exception: 
                 return {"available": False, "version": None}
         except Exception as e:
@@ -202,8 +203,7 @@ class UpdateChecker:
                 logger.info(f"Update check cancelled before pulling {base_name}:{current_tag} on {server_name}")
                 return {"available": False, "version": None}
             
-            is_update_available = self._pull_and_compare(client, container_image_id, base_name, resolved_tag, server_name)
-            result = {"available": is_update_available, "version": resolved_tag if is_update_available else None}
+            result = self._pull_and_compare(client, container_image_id, base_name, resolved_tag, server_name)
             self.set_cache_result(cache_key, result)
             return result
                 
@@ -211,6 +211,28 @@ class UpdateChecker:
             if not self._cancellation.is_cancelled():
                 logger.error(f"Error checking image updates for '{container.name}' on {server_name}: {e}")
             return {"available": False, "version": None}
+
+    def _extract_image_version(self, image_obj, default_tag):
+        labels = image_obj.labels or {}
+        for key in ['org.opencontainers.image.version', 'version', 'build_version']:
+            if key in labels and labels[key]:
+                # In some images like linuxserver, build_version might be verbose:
+                # 'Linuxserver.io version:- 4.0.19.2979-ls320 Build-date:- 2026-07-18T00:16:13+00:00'
+                # Let's just return the label value directly unless it's too long, but org.opencontainers.image.version is clean.
+                # Prioritize 'org.opencontainers.image.version'
+                if key == 'org.opencontainers.image.version':
+                    return labels[key]
+                elif 'version:-' in labels[key]:
+                    return labels[key].split('version:-')[1].strip().split(' ')[0].strip()
+                return labels[key]
+
+        for env in image_obj.attrs.get('Config', {}).get('Env', []):
+            if '=' in env:
+                k, v = env.split('=', 1)
+                if 'VERSION' in k and v:
+                    return v
+
+        return default_tag
 
     def _parse_image_name(self, image_name):
         if ':' in image_name: 
@@ -242,11 +264,13 @@ class UpdateChecker:
             updated_image = client.images.get(f"{base_name}:{current_tag}")
             result = container_image_id != updated_image.id
             
+            update_version = self._extract_image_version(updated_image, current_tag) if result else None
+
             if result:
                 logger.info(
                     f"\033[96m[{server_name}]\033[0m "
                     f"\033[93mUpdate available\033[0m  "
-                    f"\033[0m{base_name}:\033[96m{current_tag}\033[0m "
+                    f"\033[0m{base_name}:\033[96m{update_version}\033[0m "
                 )
             else:
                 logger.info(
@@ -255,7 +279,7 @@ class UpdateChecker:
                     f"{base_name}:{current_tag}"
                 )
             
-            return result
+            return {"available": result, "version": update_version}
             
         except Exception as pull_error:
                 if self._cancellation.is_cancelled():

--- a/dockpeek/update.py
+++ b/dockpeek/update.py
@@ -83,7 +83,10 @@ class UpdateChecker:
         self._executor = ThreadPoolExecutor(max_workers=2)
         self._floating_tag_mode = os.getenv('UPDATE_FLOATING_TAGS', 'disabled').lower()
     
-    def _resolve_floating_tag(self, current_tag: str) -> str:
+    def _resolve_floating_tag(self, current_tag: str, labels: dict = None) -> str:
+        if labels and 'dockpeek.update-tag' in labels:
+            return labels['dockpeek.update-tag']
+
         if self._floating_tag_mode == 'disabled' or current_tag == 'latest':
             return current_tag
 
@@ -151,9 +154,11 @@ class UpdateChecker:
             image_name = container.attrs.get('Config', {}).get('Image', '')
             if not image_name: 
                 return False
+
+            labels = container.attrs.get('Config', {}).get('Labels', {}) or {}
                 
             base_name, current_tag = self._parse_image_name(image_name)
-            resolved_tag = self._resolve_floating_tag(current_tag)
+            resolved_tag = self._resolve_floating_tag(current_tag, labels)
                 
             try:
                 local_image = client.images.get(f"{base_name}:{resolved_tag}")
@@ -184,8 +189,10 @@ class UpdateChecker:
                 logger.info(f"Using cached update result for {server_name}:{container.name}")
                 return cached_result
             
+            labels = container.attrs.get('Config', {}).get('Labels', {}) or {}
+
             base_name, current_tag = self._parse_image_name(image_name)
-            resolved_tag = self._resolve_floating_tag(current_tag)
+            resolved_tag = self._resolve_floating_tag(current_tag, labels)
 
             if resolved_tag != current_tag:
                 logger.info(f"[{server_name}] Checking floating tag: {current_tag} → {resolved_tag}")

--- a/dockpeek/update.py
+++ b/dockpeek/update.py
@@ -85,7 +85,7 @@ class UpdateChecker:
     
     def _resolve_floating_tag(self, current_tag: str, labels: dict = None) -> str:
         if labels and 'dockpeek.update-tag' in labels:
-            return labels['dockpeek.update-tag']
+            return labels['dockpeek.update-tag'] or 'latest'
 
         if self._floating_tag_mode == 'disabled' or current_tag == 'latest':
             return current_tag


### PR DESCRIPTION
Quick QoL feature via Jules (Yay AI Slop!) for checking your compose files for a docker label that will check for new image versions in the case of using a specific version in your compose file. Goal is to give a quick glimpse of updates available to images instead of having to track down hub images one by one. 